### PR TITLE
fix: enforce authentication before loading leaderboard

### DIFF
--- a/frontend/src/components/leaderboard/LeaderboardScreen/LeaderboardScreen.tsx
+++ b/frontend/src/components/leaderboard/LeaderboardScreen/LeaderboardScreen.tsx
@@ -11,10 +11,12 @@ import {
 
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
+import { useAuthCheck } from '../../../hooks/useAuthCheck';
 import { nakamaService } from '../../../services/nakama';
+import { usePlayer } from '../../../state/PlayerContext';
 import { colors } from '../../../styles/colors';
 import { layout, radius, spacing } from '../../../styles/dimensions';
 import { typography } from '../../../styles/typography';
@@ -83,21 +85,23 @@ const LeaderboardRow: React.FC<{ entry: LeaderboardEntry; isCurrentUser?: boolea
 
 export const LeaderboardScreen: React.FC = () => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const { playerName } = usePlayer();
+  const trimmedName = playerName.trim();
+  const hasPlayerName = trimmedName.length > 0;
+  const { ensureAuthenticated } = useAuthCheck();
   const [leaderboardData, setLeaderboardData] = useState<LeaderboardEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const isMountedRef = useRef(true);
 
   useEffect(() => {
-    // Get current user ID from session
-    const session = nakamaService.getSession();
-    if (session && session.user_id) {
-      setCurrentUserId(session.user_id);
-    }
-    loadLeaderboard();
+    return () => {
+      isMountedRef.current = false;
+    };
   }, []);
 
-  const loadLeaderboard = async () => {
+  const loadLeaderboard = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
@@ -129,14 +133,55 @@ export const LeaderboardScreen: React.FC = () => {
         });
       }
 
-      setLeaderboardData(leaderboardEntries);
+      if (isMountedRef.current) {
+        setLeaderboardData(leaderboardEntries);
+      }
     } catch (err) {
       console.error('Failed to load leaderboard:', err);
-      setError('Failed to load leaderboard data');
+      if (isMountedRef.current) {
+        setError('Failed to load leaderboard data');
+      }
     } finally {
-      setLoading(false);
+      if (isMountedRef.current) {
+        setLoading(false);
+      }
     }
-  };
+  }, []);
+
+  const verifyAndLoad = useCallback(async () => {
+    if (!hasPlayerName) {
+      if (isMountedRef.current) {
+        setLoading(false);
+      }
+      navigation.navigate('PlayerName', { nextScreen: 'Leaderboard' });
+      return;
+    }
+
+    try {
+      await ensureAuthenticated();
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      const session = nakamaService.getSession();
+      if (isMountedRef.current) {
+        setCurrentUserId(session?.user_id ?? null);
+      }
+
+      await loadLeaderboard();
+    } catch (err) {
+      console.error('Failed to authenticate for leaderboard:', err);
+      if (isMountedRef.current) {
+        setError('Authentication required to view leaderboard.');
+        setLoading(false);
+      }
+      navigation.navigate('PlayerName', { nextScreen: 'Leaderboard' });
+    }
+  }, [ensureAuthenticated, hasPlayerName, loadLeaderboard, navigation]);
+
+  useEffect(() => {
+    void verifyAndLoad();
+  }, [verifyAndLoad]);
 
   const handleBack = () => {
     navigation.navigate('Home');
@@ -184,7 +229,13 @@ export const LeaderboardScreen: React.FC = () => {
             ) : error ? (
               <View style={styles.errorContainer}>
                 <Text style={styles.errorText}>{error}</Text>
-                <CustomButton label="Retry" onPress={loadLeaderboard} style={styles.retryButton} />
+                <CustomButton
+                  label="Retry"
+                  onPress={() => {
+                    void verifyAndLoad();
+                  }}
+                  style={styles.retryButton}
+                />
               </View>
             ) : leaderboardData.length === 0 ? (
               <View style={styles.emptyContainer}>

--- a/frontend/src/components/onboarding/PlayerNameScreen/PlayerNameScreen.tsx
+++ b/frontend/src/components/onboarding/PlayerNameScreen/PlayerNameScreen.tsx
@@ -62,6 +62,8 @@ export const PlayerNameScreen: React.FC = () => {
         navigation.navigate('MatchLoading', { mode, gameMode });
       } else if (nextScreen === 'Home') {
         navigation.navigate('Home');
+      } else if (nextScreen === 'Leaderboard') {
+        navigation.navigate('Leaderboard');
       } else if (nextScreen === 'PlayerGame') {
         navigation.navigate('PlayerGame');
       } else {
@@ -75,6 +77,8 @@ export const PlayerNameScreen: React.FC = () => {
         navigation.navigate('MatchLoading', { mode, gameMode });
       } else if (nextScreen === 'Home') {
         navigation.navigate('Home');
+      } else if (nextScreen === 'Leaderboard') {
+        navigation.navigate('Leaderboard');
       } else if (nextScreen === 'PlayerGame') {
         navigation.navigate('PlayerGame');
       } else {

--- a/frontend/src/types/components.ts
+++ b/frontend/src/types/components.ts
@@ -1,7 +1,7 @@
 import type { GameMode } from './game';
 
 export type PlayerNameScreenParams = {
-  nextScreen?: 'Home' | 'MatchLoading' | 'PlayerGame';
+  nextScreen?: 'Home' | 'MatchLoading' | 'PlayerGame' | 'Leaderboard';
   mode?: 'bot' | 'player'; // For when nextScreen is 'MatchLoading'
   gameMode?: GameMode; // For when nextScreen is 'MatchLoading' and mode is 'player'
 };


### PR DESCRIPTION
## Summary
- add an authentication pre-check on the leaderboard screen so unauthenticated users are routed through name entry
- allow the player name flow to return to the leaderboard after successful authentication

## Testing
- pnpm --filter frontend lint

------
https://chatgpt.com/codex/tasks/task_b_68de73c72c1083228b7b6892ac4a1723